### PR TITLE
Add a job to perform a scan on Polkadot node from CLI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.3.0
         with:
           path: license-scanner
       - name: Setup Node.js for use with actions


### PR DESCRIPTION
This aims to achieve two things:

- Make sure that the CLI is working fine (the current tests omit the CLI args parsing and execution)
- Make sure that we catch a situation where we degrade scan performance significantly