### PR TITLE
Enable debug logs in tests by setting env variable

### DIFF
--- a/tests/scanner.test.ts
+++ b/tests/scanner.test.ts
@@ -31,7 +31,7 @@ describe("Scanner tests", () => {
       dirs: { crates: cratesDir, repositories: repositoriesDir },
       rust: { shouldCheckForCargoLock: true, cargoExecPath: "cargo", rustCrateScannerRoot },
       detectionOverrides: null,
-      logger: new Logger({ minLevel: "info" }),
+      logger: new Logger({ minLevel: process.env.DEBUG ? "debug" : "info" }),
     };
   });
 


### PR DESCRIPTION
Can be useful to do:

```
DEBUG=1 yarn test
```

and see the debug logs easily in the tests.