### PR TITLE
Add source maps when running tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "fix:eslint": "yarn run eslint -- --fix",
     "fix:prettier": "yarn run prettier -- --write",
     "fix": "yarn run fix:eslint && yarn run fix:prettier",
-    "test": "mocha",
+    "test": "yarn build --sourceMap && mocha",
     "debug": "NODE_OPTIONS='--inspect-brk' yarn run start"
   },
   "dependencies": {


### PR DESCRIPTION
- This way debugging with breakpoints works in IDE
- Also rebuilds the tests before running which is useful because we no longer use `ts-node` so a build is needed before tests