### PR TITLE
renamed package name to have organization scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "license-scanner",
+  "name": "@paritytech/license-scanner",
   "version": "0.0.1",
   "author": "Parity <admin@parity.io> (https://parity.io)",
   "type": "module",


### PR DESCRIPTION
The publish action failed as the scope for the organization was missing.