### PR TITLE
Use commander.js for CLI arguments

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Dump into csv
         working-directory: polkadot
         run: |
-          license-scanner dump csv $(realpath ./node) ./output.csv
+          license-scanner dump $(realpath ./node) ./output.csv
           # Check a couple of rows to make sure we have the output we expected.
           grep -q '"metrics/src/lib.rs","GPL-3.0-only"' ./output.csv
           grep -q '"overseer/src/tests.rs","GPL-3.0-only"' ./output.csv
@@ -65,10 +65,9 @@ jobs:
 
           license-scanner scan \
             --log-level debug \
-            --ensure-licenses Apache-2.0 \
-            --ensure-licenses GPL-3.0-only \
+            --ensure-licenses Apache-2.0 GPL-3.0-only \
             --exclude ./**/target ./**/weights \
-            --include ./**/src/**/*.rs \
+            -- ./**/src/**/*.rs \
             && exit 1 || exit 0
             # We expected it to fail because there are some unlicensed files left.
         working-directory: polkadot

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -64,10 +64,13 @@ jobs:
           shopt -s globstar
 
           license-scanner scan \
-            --log-level debug \
             --ensure-licenses Apache-2.0 GPL-3.0-only \
             --exclude ./**/target ./**/weights \
             -- ./**/src/**/*.rs \
+            2>out.txt \
             && exit 1 || exit 0
             # We expected it to fail because there are some unlicensed files left.
+          
+          grep -q 'No license detected in reconstruct.rs. Exact file path:' ./out.txt
+          grep -q 'No license detected in mod.rs. Exact file path:' ./out.txt
         working-directory: polkadot

--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ yarn install
 yarn build
 
 # use `scan` for scanning
-yarn start -- scan /directory/or/file
+yarn start scan /directory/or/file [...more/directories/or/files]
 
 # after the scan is complete, optionally dump it to CSV
-yarn start -- dump csv /directory/or/file /output.csv
+yarn start dump /directory/or/file /output.csv
 ```
 
 If a single file is provided, the scan will be performed exclusively for that
@@ -253,14 +253,15 @@ Doing so will remove the specified boilerplate lines from **the top** of the
 licenses so that the detector will be able get to the actual license's text
 cleanly.
 
-## `--ensure-licenses` <a name="ensure-licenses"></a>
+## `--ensure-licenses` and `--ensure-any-license` <a name="ensure-licenses"></a>
 
-If configured, the scan will make sure that all scanned files are licensed.
+If configured, the scan will make sure that all scanned files are licensed with some license.
 
-- If set to `true`, the scan will make sure that all source files have some license detected.
-- If set to a specific license(s), the scan will make sure that all source files have one of those licenses detected.
+- With `--ensure-licenses`, every file needs to be licenses with one of the provided licenses.
+- With `--ensure-any-license`, every file needs to be licenses with any license.
 
-By default, it is `false` - meaning no license enforcement.
+Those options are conflicting with each other so only one should be specified.
+By default, no licensing is enforced.
 
 ## `--exclude` <a name="exclude"></a>
 
@@ -268,25 +269,7 @@ Can be used to exclude files or directories from the scan.
 
 - Most useful in the combination with `--ensure-licenses`.
 - The excluded path can be absolute or relative.
-- `--include` must be used explicitly to mark the end of `--exclude` parameters.
-
-## `--include` <a name="include"></a>
-
-Which files or directories to target with the scan.
-
-Example:
-
-```bash
-yarn start -- scan --include /directory/or/file
-```
-
-In most cases can be omitted:
-
-```bash
-yarn start -- scan --include /directory/or/file
-```
-
-- `--include` must be used explicitly to mark the end of `--exclude` parameters.
+- Another option starting with `--xxx` or `--` must be used explicitly to mark the end of `--exclude` parameters.
 
 # Implementation <a name="implementation"></a>
 

--- a/README.md
+++ b/README.md
@@ -261,10 +261,17 @@ cleanly.
 
 ## `--ensure-licenses` and `--ensure-any-license` <a name="ensure-licenses"></a>
 
-If configured, the scan will make sure that all scanned files are licensed with some license.
+If configured, the scan will make sure that all scanned files are licensed.
 
 - With `--ensure-licenses`, every file needs to be licenses with one of the provided licenses.
 - With `--ensure-any-license`, every file needs to be licenses with any license.
+
+Examples:
+
+```bash
+yarn start -- scan --ensure-licenses Apache-2.0 GPL-3.0-only -- /directory/or/file
+yarn start -- scan --ensure-any-license /directory/or/file
+```
 
 Those options are conflicting with each other so only one should be specified.
 By default, no licensing is enforced.

--- a/README.md
+++ b/README.md
@@ -59,10 +59,14 @@ yarn install
 yarn build
 
 # use `scan` for scanning
-yarn start scan /directory/or/file [...more/directories/or/files]
+yarn start -- scan /directory/or/file [...more/directories/or/files]
+
+# Mark the end of variadic options with a `--` or another non-variadic `--xxx` option
+yarn start -- scan --exclude target/debug target/release -- /directory/or/file
+yarn start -- scan --exclude target/debug target/release --log-level debug /directory/or/file
 
 # after the scan is complete, optionally dump it to CSV
-yarn start dump /directory/or/file /output.csv
+yarn start -- dump /directory/or/file /output.csv
 ```
 
 If a single file is provided, the scan will be performed exclusively for that
@@ -269,7 +273,6 @@ Can be used to exclude files or directories from the scan.
 
 - Most useful in the combination with `--ensure-licenses`.
 - The excluded path can be absolute or relative.
-- Another option starting with `--xxx` or `--` must be used explicitly to mark the end of `--exclude` parameters.
 
 # Implementation <a name="implementation"></a>
 

--- a/license-scanner/cli/dump.ts
+++ b/license-scanner/cli/dump.ts
@@ -37,9 +37,7 @@ export const executeDump = async function ({ outputFile, scanRoot }: DumpCliArgs
   const lines: string[] = [];
   for (const [id, result] of Object.entries(collection)) {
     lines.push(
-      `${escapeValueForCsv(id)},${escapeValueForCsv(
-        "license" in result ? result.license : result.description ?? "",
-      )}`,
+      `${escapeValueForCsv(id)},${escapeValueForCsv("license" in result ? result.license : result.description ?? "")}`,
     );
   }
 

--- a/license-scanner/cli/dump.ts
+++ b/license-scanner/cli/dump.ts
@@ -21,7 +21,7 @@ const escapeValueForCsv = function (value: unknown) {
   }
 };
 
-export const executeDumpArgs = async function ({ outputFile, scanRoot }: DumpCliArgs) {
+export const executeDump = async function ({ outputFile, scanRoot }: DumpCliArgs) {
   const db: DatabaseLayout = JSON.parse((await readFileAsync(databasePath)).toString());
 
   const scanResult = db.scanResult;

--- a/license-scanner/cli/dump.ts
+++ b/license-scanner/cli/dump.ts
@@ -2,28 +2,6 @@ import { databasePath } from "license-scanner/constants";
 import { DatabaseLayout, DumpCliArgs } from "license-scanner/types";
 import { readFileAsync, writeFileAsync } from "license-scanner/utils";
 
-const formats: { [Format in DumpCliArgs["args"]["format"]]: null } = { csv: null };
-
-export const parseDumpArgs = function (args: string[]) {
-  const format = args.shift();
-
-  if (format === undefined || !(format in formats)) {
-    throw new Error(`Must specify the output format in the first argument. Valid ones are: ${Object.keys(formats)}`);
-  }
-
-  const scanRoot = args.shift();
-  if (scanRoot === undefined) {
-    throw new Error("Must specify the directory where the results will be dumped from");
-  }
-
-  const outputFile = args.shift();
-  if (outputFile === undefined) {
-    throw new Error("Must specify the output file in the second argument");
-  }
-
-  return new DumpCliArgs({ format: format as DumpCliArgs["args"]["format"], outputFile, scanRoot });
-};
-
 const escapeValueForCsv = function (value: unknown) {
   if (value === null || value === undefined) {
     return "";
@@ -43,37 +21,27 @@ const escapeValueForCsv = function (value: unknown) {
   }
 };
 
-export const executeDumpArgs = async function ({ args: { format, outputFile, scanRoot } }: DumpCliArgs) {
-  switch (format) {
-    case "csv": {
-      const db: DatabaseLayout = JSON.parse((await readFileAsync(databasePath)).toString());
+export const executeDumpArgs = async function ({ outputFile, scanRoot }: DumpCliArgs) {
+  const db: DatabaseLayout = JSON.parse((await readFileAsync(databasePath)).toString());
 
-      const scanResult = db.scanResult;
-      if (scanResult === undefined) {
-        throw new Error(`No scan result was found from the database at ${databasePath}`);
-      }
-
-      const collection = scanResult[scanRoot];
-      if (collection === undefined) {
-        throw new Error(`No scan result was found for the directory "${scanRoot}" on the database ${databasePath}`);
-      }
-
-      const lines: string[] = [];
-      for (const [id, result] of Object.entries(collection)) {
-        lines.push(
-          `${escapeValueForCsv(id)},${escapeValueForCsv(
-            "license" in result ? result.license : result.description ?? "",
-          )}`,
-        );
-      }
-
-      await writeFileAsync(outputFile, ["id,verdict"].concat(lines).join("\n"));
-
-      break;
-    }
-    default: {
-      const _: never = format;
-      throw new Error(`Format is not covered: ${format}`);
-    }
+  const scanResult = db.scanResult;
+  if (scanResult === undefined) {
+    throw new Error(`No scan result was found from the database at ${databasePath}`);
   }
+
+  const collection = scanResult[scanRoot];
+  if (collection === undefined) {
+    throw new Error(`No scan result was found for the directory "${scanRoot}" on the database ${databasePath}`);
+  }
+
+  const lines: string[] = [];
+  for (const [id, result] of Object.entries(collection)) {
+    lines.push(
+      `${escapeValueForCsv(id)},${escapeValueForCsv(
+        "license" in result ? result.license : result.description ?? "",
+      )}`,
+    );
+  }
+
+  await writeFileAsync(outputFile, ["id,verdict"].concat(lines).join("\n"));
 };

--- a/license-scanner/cli/scan.ts
+++ b/license-scanner/cli/scan.ts
@@ -9,7 +9,7 @@ import {
 } from "license-scanner/constants";
 import { ensureDatabase, getSaveScanResultItem } from "license-scanner/db";
 import { getLicenseMatcher, loadLicensesNormalized, throwLicensingErrors } from "license-scanner/license";
-import { Logger, LogLevel } from "license-scanner/logger";
+import { Logger } from "license-scanner/logger";
 import { scan } from "license-scanner/scanner";
 import {
   DetectionOverride,
@@ -20,7 +20,7 @@ import {
   ScanTracker,
 } from "license-scanner/types";
 import { lstatAsync, readFileAsync, shouldExclude } from "license-scanner/utils";
-import { dirname, join as joinPath, resolve as resolvePath } from "path";
+import { dirname, join as joinPath } from "path";
 
 export const readStartLinesExcludes = async (
   startLinesExcludes: string | undefined,
@@ -38,8 +38,10 @@ export const readEnsureLicenses = (opts: {
   return false;
 };
 
-export const readDetectionOverrides = async (overridesFile: string | undefined): Promise<ScanCliArgs["detectionOverrides"]> => {
-  if (!overridesFile) return []
+export const readDetectionOverrides = async (
+  overridesFile: string | undefined,
+): Promise<ScanCliArgs["detectionOverrides"]> => {
+  if (!overridesFile) return [];
   const overridesFileDirectory = dirname(overridesFile);
 
   const parsedOverrides: DetectionOverrideInput[] = JSON.parse((await readFileAsync(overridesFile)).toString());

--- a/license-scanner/cli/scan.ts
+++ b/license-scanner/cli/scan.ts
@@ -22,179 +22,69 @@ import {
 import { lstatAsync, readFileAsync, shouldExclude } from "license-scanner/utils";
 import { dirname, join as joinPath, resolve as resolvePath } from "path";
 
-type NextState =
-  | "read startLinesExcludes"
-  | "read detectionOverrides"
-  | "read logLevel"
-  | "read ensureLicenses"
-  | "read exclude"
-  | "read include"
-  | null;
-
-const detectOption = (arg: string): NextState => {
-  const argIsOption = function (optionName: string) {
-    return arg === `-${optionName}` || arg === `-${optionName}=`;
-  };
-  if (argIsOption("-start-lines-excludes")) {
-    return "read startLinesExcludes";
-  }
-  if (argIsOption("-detection-overrides")) {
-    return "read detectionOverrides";
-  }
-  if (argIsOption("-log-level")) {
-    return "read logLevel";
-  }
-  if (argIsOption("-ensure-licenses")) {
-    return "read ensureLicenses";
-  }
-  if (argIsOption("-exclude")) {
-    return "read exclude";
-  }
-  if (argIsOption("-include")) {
-    return "read include";
-  }
-  return null;
+export const readStartLinesExcludes = async (
+  startLinesExcludes: string | undefined,
+): Promise<ScanCliArgs["startLinesExcludes"]> => {
+  if (!startLinesExcludes) return [];
+  return (await readFileAsync(startLinesExcludes)).toString().trim().split("\n");
 };
 
-export const parseScanArgs = async function (args: string[]): Promise<ScanCliArgs> {
-  const scanRoots: string[] = [];
-  const exclude: string[] = [];
-  let startLinesExcludes: string[] | null = null;
-  let detectionOverrides: DetectionOverride[] | null = null;
-  let logLevel: LogLevel = "info";
-  let ensureLicenses: boolean | string[] = false;
+export const readEnsureLicenses = (opts: {
+  ensureLicenses?: string[] | undefined;
+  ensureAnyLicense?: true | undefined;
+}): ScanCliArgs["ensureLicenses"] => {
+  if (opts.ensureAnyLicense === true) return true;
+  if (opts.ensureLicenses && opts.ensureLicenses.length > 0) return opts.ensureLicenses;
+  return false;
+};
 
-  let nextState: NextState = null;
+export const readDetectionOverrides = async (overridesFile: string | undefined): Promise<ScanCliArgs["detectionOverrides"]> => {
+  if (!overridesFile) return []
+  const overridesFileDirectory = dirname(overridesFile);
 
-  while (true) {
-    const arg = args.shift();
-    if (arg === undefined) {
-      break;
+  const parsedOverrides: DetectionOverrideInput[] = JSON.parse((await readFileAsync(overridesFile)).toString());
+
+  const overrides: DetectionOverride[] = [];
+  const uids = new Set();
+  for (const { compare_with: comparisonFile, ...parsedOverride } of parsedOverrides) {
+    const uid = "id" in parsedOverride ? parsedOverride.id : parsedOverride.starts_with;
+
+    if (uids.has(uid)) {
+      throw new Error(`Duplicate id ${uid} in the provided detectionOverrides`);
+    } else {
+      uids.add(uid);
     }
 
-    switch (nextState) {
-      case "read logLevel": {
-        nextState = null;
+    if (typeof parsedOverride.result !== "object") {
+      throw new Error(`Result of override rule ${uid} should be an object or null`);
+    }
 
-        switch (arg) {
-          case "error":
-          case "debug":
-          case "info": {
-            logLevel = arg;
-            break;
-          }
-          default: {
-            throw new Error(`Invalid log level "${arg}"`);
-          }
-        }
-        break;
-      }
-      case "read startLinesExcludes": {
-        nextState = null;
+    let contents: string | null = null;
+    if (comparisonFile !== undefined) {
+      const path = comparisonFile.startsWith("./") ? joinPath(overridesFileDirectory, comparisonFile) : comparisonFile;
+      contents = (await readFileAsync(path)).toString();
+    }
 
-        startLinesExcludes = (await readFileAsync(arg)).toString().trim().split("\n");
-        break;
-      }
-      case "read detectionOverrides": {
-        nextState = null;
-
-        const overridesFile = arg;
-        const overridesFileDirectory = dirname(overridesFile);
-
-        const parsedOverrides: DetectionOverrideInput[] = JSON.parse((await readFileAsync(overridesFile)).toString());
-
-        const overrides: DetectionOverride[] = [];
-        const uids = new Set();
-        for (const { compare_with: comparisonFile, ...parsedOverride } of parsedOverrides) {
-          const uid = "id" in parsedOverride ? parsedOverride.id : parsedOverride.starts_with;
-
-          if (uids.has(uid)) {
-            throw new Error(`Duplicate id ${uid} in the provided detectionOverrides`);
-          } else {
-            uids.add(uid);
-          }
-
-          if (typeof parsedOverride.result !== "object") {
-            throw new Error(`Result of override rule ${uid} should be an object or null`);
-          }
-
-          let contents: string | null = null;
-          if (comparisonFile !== undefined) {
-            const path = comparisonFile.startsWith("./")
-              ? joinPath(overridesFileDirectory, comparisonFile)
-              : comparisonFile;
-            contents = (await readFileAsync(path)).toString();
-          }
-
-          if ("id" in parsedOverride) {
-            overrides.push(new DetectionOverrideById(parsedOverride.result, contents, uid));
-          } else if ("starts_with" in parsedOverride) {
-            overrides.push(new DetectionOverrideByStartsWith(parsedOverride.result, contents, uid));
-          } else {
-            const _: never = parsedOverride;
-            throw new Error(`Not exhaustive parsedOverride rule: ${JSON.stringify(parsedOverride)}`);
-          }
-        }
-
-        detectionOverrides = overrides;
-        break;
-      }
-      case "read ensureLicenses": {
-        nextState = null;
-
-        if (["true", "True"].includes(arg)) {
-          ensureLicenses = true;
-        } else if (["false", "False"].includes(arg)) {
-          ensureLicenses = false;
-        } else if (typeof ensureLicenses === "boolean") {
-          ensureLicenses = [arg];
-        } else {
-          ensureLicenses.push(arg);
-        }
-        break;
-      }
-      case "read exclude": {
-        let excludeArg: string | undefined = arg;
-        while (excludeArg !== undefined && detectOption(excludeArg) === null) {
-          // Continue slurping exclude parameters until another option is found.
-          exclude.push(excludeArg);
-          excludeArg = args.shift();
-        }
-        nextState = excludeArg ? detectOption(excludeArg) : null;
-        break;
-      }
-      case "read include":
-      case null: {
-        if (detectOption(arg) !== null) {
-          nextState = detectOption(arg);
-        } else {
-          scanRoots.push(arg);
-        }
-        break;
-      }
-      default: {
-        const _: never = nextState;
-        throw new Error(`Not exhaustive nextState: ${nextState}`);
-      }
+    if ("id" in parsedOverride) {
+      overrides.push(new DetectionOverrideById(parsedOverride.result, contents, uid));
+    } else if ("starts_with" in parsedOverride) {
+      overrides.push(new DetectionOverrideByStartsWith(parsedOverride.result, contents, uid));
+    } else {
+      const _: never = parsedOverride;
+      throw new Error(`Not exhaustive parsedOverride rule: ${JSON.stringify(parsedOverride)}`);
     }
   }
 
-  if (scanRoots.length === 0) {
-    throw new Error("Required argument: scanRoot");
-  }
-
-  return {
-    scanRoots: scanRoots.map((scanRoot) => resolvePath(scanRoot)),
-    exclude,
-    startLinesExcludes,
-    detectionOverrides,
-    logLevel,
-    ensureLicenses,
-  };
+  return overrides;
 };
 
-export const executeScanArgs = async function ({
-  scanRoots, startLinesExcludes, detectionOverrides, logLevel, ensureLicenses, exclude
+export const executeScan = async function ({
+  scanRoots,
+  startLinesExcludes,
+  detectionOverrides,
+  logLevel,
+  ensureLicenses,
+  exclude,
 }: ScanCliArgs) {
   const licenses = await loadLicensesNormalized(joinPath(buildRoot, "licenses"), {
     aliases: licenseAliases,

--- a/license-scanner/cli/scan.ts
+++ b/license-scanner/cli/scan.ts
@@ -56,7 +56,7 @@ const detectOption = (arg: string): NextState => {
   return null;
 };
 
-export const parseScanArgs = async function (args: string[]) {
+export const parseScanArgs = async function (args: string[]): Promise<ScanCliArgs> {
   const scanRoots: string[] = [];
   const exclude: string[] = [];
   let startLinesExcludes: string[] | null = null;
@@ -183,18 +183,18 @@ export const parseScanArgs = async function (args: string[]) {
     throw new Error("Required argument: scanRoot");
   }
 
-  return new ScanCliArgs({
+  return {
     scanRoots: scanRoots.map((scanRoot) => resolvePath(scanRoot)),
     exclude,
     startLinesExcludes,
     detectionOverrides,
     logLevel,
     ensureLicenses,
-  });
+  };
 };
 
 export const executeScanArgs = async function ({
-  args: { scanRoots, startLinesExcludes, detectionOverrides, logLevel, ensureLicenses, exclude },
+  scanRoots, startLinesExcludes, detectionOverrides, logLevel, ensureLicenses, exclude
 }: ScanCliArgs) {
   const licenses = await loadLicensesNormalized(joinPath(buildRoot, "licenses"), {
     aliases: licenseAliases,

--- a/license-scanner/main.ts
+++ b/license-scanner/main.ts
@@ -1,8 +1,52 @@
 #!/usr/bin/env -S node --es-module-specifier-resolution=node
 
+import { Command, Option } from '@commander-js/extra-typings';
+
 import { executeDumpArgs, parseDumpArgs } from "./cli/dump";
 import { executeScanArgs, parseScanArgs } from "./cli/scan";
 import { DumpCliArgs, ScanCliArgs } from "./types";
+import {LogLevel} from "license-scanner/logger";
+
+const program = new Command("license-scanner").description(
+  `license-scanner does not provide legal advice and it is not a lawyer. Licenses
+are identified exclusively by automated means, without any step of human
+verification, and thus the verdict is subject to bugs in the software and
+incomplete heuristics which might yield false positives.
+
+license-scanner aims to provide best-effort automated license scanning.
+Regardless of how well it performs, its accuracy should not be relied upon as
+the ultimate verdict for legal purposes. You should seek independent legal
+advice for any licensing questions that may arise from using this tool.
+`,
+);
+
+program.command('scan')
+  .description(`Perform a scan trying to detect licenses in the target files.`)
+  .argument('<scanRoots...>')
+  .option('--detection-overrides <detectionOverrides>', 'Takes as argument a configuration file specifying Override Rules ([example](https://github.com/paritytech/license-scanner/blob/master/example/detection-overrides.json)) which can be used to override the automatic detection.')
+  .option('--start-lines-excludes <startLineExcludes>', 'Takes as argument a plain-text file which specifies lines to be excluded from the top of the file during the text normalization step')
+  .addOption(new Option('--log-level <level>').choices(["error", "debug", "info"]))
+  .option('--ensure-licenses <license>', 'If configured, the scan will make sure that all scanned files are licensed.')
+  .option('--exclude <exclude...>', 'Can be used to exclude files or directories from the scan.')
+  .action((scanRoots, options) => {
+    console.log({scanRoots, options})
+  })
+
+program.command('dump')
+  .description(`After the scan is complete it can optionally be dumped into a CSV file.`)
+  .argument("Scan root <scanRoot>", `The directory where the results of a scan are.`)
+  .argument('outputFile <outputFile>', 'Output path or filename.')
+  .action((scanRoot, outputFile) => {
+    console.log('dump options:', {scanRoot, outputFile})
+  })
+
+program.parse();
+
+// const options = program.opts();
+// const args = program.args;
+// console.log({options, args})
+
+process.exit(0);
 
 const subcommands = {
   dump: { parse: parseDumpArgs, execute: executeDumpArgs },

--- a/license-scanner/main.ts
+++ b/license-scanner/main.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env -S node --es-module-specifier-resolution=node
 
 import { Command, Option } from "@commander-js/extra-typings";
+import { Logger, LogLevel } from "license-scanner/logger";
+import { resolve as resolvePath } from "path";
 
 import { executeDump } from "./cli/dump";
 import { executeScan, readDetectionOverrides, readEnsureLicenses, readStartLinesExcludes } from "./cli/scan";
-import { Logger, LogLevel } from "license-scanner/logger";
-import {resolve as resolvePath} from "path";
 
 const program = new Command("license-scanner").description(
   `license-scanner does not provide legal advice and it is not a lawyer. Licenses
@@ -52,7 +52,9 @@ program
     ).conflicts("--ensure-licenses"),
   )
   .option("--exclude <exclude...>", "Can be used to exclude files or directories from the scan.")
-  .action(async (scanRoots, options, asd) => {
+  // It's actually correct usage but @commander-js/extra-typings is wrong on this one.
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
+  .action(async (scanRoots, options) => {
     const logger = new Logger({ minLevel: options.logLevel as LogLevel });
     try {
       await executeScan({
@@ -75,6 +77,8 @@ program
   .argument("Scan root <scanRoot>", `The directory where the results of a scan are.`)
   .argument("outputFile <outputFile>", "Output path or filename.")
   .addOption(logOption)
+  // It's actually correct usage but @commander-js/extra-typings is wrong on this one.
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   .action(async (scanRoot, outputFile, options) => {
     const logger = new Logger({ minLevel: options.logLevel as LogLevel });
     try {

--- a/license-scanner/main.ts
+++ b/license-scanner/main.ts
@@ -43,13 +43,13 @@ program
     new Option(
       "--ensure-licenses <licenses...>",
       "If configured, the scan will make sure that all scanned files are licensed with one of the listed licenses.",
-    ).conflicts("--ensure-any-license"),
+    ).conflicts("ensureAnyLicense"),
   )
   .addOption(
     new Option(
       "--ensure-any-license",
       "If configured, the scan will make sure that all scanned files are licensed with any license.",
-    ).conflicts("--ensure-licenses"),
+    ).conflicts("ensureLicenses"),
   )
   .option("--exclude <exclude...>", "Can be used to exclude files or directories from the scan.")
   // It's actually correct usage but @commander-js/extra-typings is wrong on this one.

--- a/license-scanner/main.ts
+++ b/license-scanner/main.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env -S node --es-module-specifier-resolution=node
 
-import { Command, Option } from '@commander-js/extra-typings';
+import { Command, Option } from "@commander-js/extra-typings";
 
-import { executeDumpArgs, parseDumpArgs } from "./cli/dump";
-import { executeScanArgs, parseScanArgs } from "./cli/scan";
-import { DumpCliArgs, ScanCliArgs } from "./types";
-import {LogLevel} from "license-scanner/logger";
+import { executeDump } from "./cli/dump";
+import { executeScan, readDetectionOverrides, readEnsureLicenses, readStartLinesExcludes } from "./cli/scan";
+import { Logger, LogLevel } from "license-scanner/logger";
+import {resolve as resolvePath} from "path";
 
 const program = new Command("license-scanner").description(
   `license-scanner does not provide legal advice and it is not a lawyer. Licenses
@@ -20,67 +20,72 @@ advice for any licensing questions that may arise from using this tool.
 `,
 );
 
-program.command('scan')
-  .description(`Perform a scan trying to detect licenses in the target files.`)
-  .argument('<scanRoots...>')
-  .option('--detection-overrides <detectionOverrides>', 'Takes as argument a configuration file specifying Override Rules ([example](https://github.com/paritytech/license-scanner/blob/master/example/detection-overrides.json)) which can be used to override the automatic detection.')
-  .option('--start-lines-excludes <startLineExcludes>', 'Takes as argument a plain-text file which specifies lines to be excluded from the top of the file during the text normalization step')
-  .addOption(new Option('--log-level <level>').choices(["error", "debug", "info"]))
-  .option('--ensure-licenses <license>', 'If configured, the scan will make sure that all scanned files are licensed.')
-  .option('--exclude <exclude...>', 'Can be used to exclude files or directories from the scan.')
-  .action((scanRoots, options) => {
-    console.log({scanRoots, options})
-  })
+const logOption = new Option("--log-level <level>").choices(["error", "debug", "info"]).default("info");
 
-program.command('dump')
+program
+  .command("scan")
+  .description(`Perform a scan trying to detect licenses in the target files.`)
+  .argument("<scanRoots...>")
+  .addOption(
+    new Option<"--log-level <level>", LogLevel>("--log-level <level>")
+      .choices(["error", "debug", "info"] as const)
+      .default("info"),
+  )
+  .option(
+    "--detection-overrides <detectionOverrides>",
+    "Takes as argument a configuration file specifying Override Rules ([example](https://github.com/paritytech/license-scanner/blob/master/example/detection-overrides.json)) which can be used to override the automatic detection.",
+  )
+  .option(
+    "--start-lines-excludes <startLineExcludes>",
+    "Takes as argument a plain-text file which specifies lines to be excluded from the top of the file during the text normalization step",
+  )
+  .addOption(
+    new Option(
+      "--ensure-licenses <licenses...>",
+      "If configured, the scan will make sure that all scanned files are licensed with one of the listed licenses.",
+    ).conflicts("--ensure-any-license"),
+  )
+  .addOption(
+    new Option(
+      "--ensure-any-license",
+      "If configured, the scan will make sure that all scanned files are licensed with any license.",
+    ).conflicts("--ensure-licenses"),
+  )
+  .option("--exclude <exclude...>", "Can be used to exclude files or directories from the scan.")
+  .action(async (scanRoots, options, asd) => {
+    const logger = new Logger({ minLevel: options.logLevel as LogLevel });
+    try {
+      await executeScan({
+        scanRoots: scanRoots.map((scanRoot) => resolvePath(scanRoot)),
+        startLinesExcludes: await readStartLinesExcludes(options.startLinesExcludes),
+        detectionOverrides: await readDetectionOverrides(options.detectionOverrides),
+        exclude: options.exclude ?? [],
+        logLevel: options.logLevel as LogLevel,
+        ensureLicenses: readEnsureLicenses(options),
+      });
+    } catch (e: any) {
+      logger.debug(e.stack);
+      program.error(e.message);
+    }
+  });
+
+program
+  .command("dump")
   .description(`After the scan is complete it can optionally be dumped into a CSV file.`)
   .argument("Scan root <scanRoot>", `The directory where the results of a scan are.`)
-  .argument('outputFile <outputFile>', 'Output path or filename.')
-  .action((scanRoot, outputFile) => {
-    console.log('dump options:', {scanRoot, outputFile})
-  })
-
-program.parse();
-
-// const options = program.opts();
-// const args = program.args;
-// console.log({options, args})
-
-process.exit(0);
-
-const subcommands = {
-  dump: { parse: parseDumpArgs, execute: executeDumpArgs },
-  scan: { parse: parseScanArgs, execute: executeScanArgs },
-};
-
-const main = async function () {
-  const cliArgs = [...process.argv.slice(2)];
-  const subcommand = cliArgs.shift();
-
-  try {
-    if (subcommand === undefined) {
-      throw new Error(`Must specify a subcommand\nThe available ones are: ${Object.keys(subcommands).join(",")}`);
+  .argument("outputFile <outputFile>", "Output path or filename.")
+  .addOption(logOption)
+  .action(async (scanRoot, outputFile, options) => {
+    const logger = new Logger({ minLevel: options.logLevel as LogLevel });
+    try {
+      await executeDump({ scanRoot, outputFile });
+    } catch (e: any) {
+      logger.debug(e.stack);
+      program.error(e.message);
     }
+  });
 
-    if (typeof subcommand !== "string" || !(subcommand in subcommands)) {
-      throw new Error(`Invalid subcommand ${subcommand}. Valid ones are: ${Object.keys(subcommands)}`);
-    }
-
-    const conf = subcommands[subcommand as keyof typeof subcommands];
-    const args = await conf.parse(cliArgs);
-
-    if (args instanceof DumpCliArgs) {
-      await subcommands.dump.execute(args);
-    } else if (args instanceof ScanCliArgs) {
-      await subcommands.scan.execute(args);
-    } else {
-      const _: never = args;
-      throw new Error(`Argument handling is not exhaustive for ${args}`);
-    }
-  } catch (error: unknown) {
-    console.error((error as Error).toString());
-    process.exit(1);
-  }
-};
-
-await main();
+program.parseAsync().catch((e) => {
+  console.error(e.toString());
+  process.exit(1);
+});

--- a/license-scanner/main.ts
+++ b/license-scanner/main.ts
@@ -26,11 +26,7 @@ program
   .command("scan")
   .description(`Perform a scan trying to detect licenses in the target files.`)
   .argument("<scanRoots...>")
-  .addOption(
-    new Option<"--log-level <level>", LogLevel>("--log-level <level>")
-      .choices(["error", "debug", "info"] as const)
-      .default("info"),
-  )
+  .addOption(logOption)
   .option(
     "--detection-overrides <detectionOverrides>",
     "Takes as argument a configuration file specifying Override Rules ([example](https://github.com/paritytech/license-scanner/blob/master/example/detection-overrides.json)) which can be used to override the automatic detection.",

--- a/license-scanner/scanner.ts
+++ b/license-scanner/scanner.ts
@@ -146,7 +146,7 @@ export const scan = async function (options: ScanOptions): Promise<ScanResult> {
 
     logger.debug(`Enqueueing file ${file.path}`);
 
-    for (const rule of detectionOverrides ?? []) {
+    for (const rule of detectionOverrides) {
       if (rule instanceof DetectionOverrideById) {
         if (key !== rule.value) {
           continue;

--- a/license-scanner/types.ts
+++ b/license-scanner/types.ts
@@ -153,6 +153,6 @@ export interface ScanCliArgs {
 }
 
 export interface DumpCliArgs {
-  scanRoot: string
-  outputFile: string
+  scanRoot: string;
+  outputFile: string;
 }

--- a/license-scanner/types.ts
+++ b/license-scanner/types.ts
@@ -143,19 +143,16 @@ export type CargoMetadataOutputV1 = {
   packages: { name: string; version: string; manifest_path: string }[];
 };
 
-export class ScanCliArgs {
-  constructor(
-    public args: {
-      scanRoots: string[];
-      exclude: string[];
-      startLinesExcludes: string[] | null;
-      detectionOverrides: DetectionOverride[] | null;
-      logLevel: LogLevel;
-      ensureLicenses: boolean | string[];
-    },
-  ) {}
+export interface ScanCliArgs {
+  scanRoots: string[];
+  exclude: string[];
+  startLinesExcludes: string[] | null;
+  detectionOverrides: DetectionOverride[] | null;
+  logLevel: LogLevel;
+  ensureLicenses: boolean | string[];
 }
 
-export class DumpCliArgs {
-  constructor(public args: { format: "csv"; outputFile: string; scanRoot: string }) {}
+export interface DumpCliArgs {
+  scanRoot: string
+  outputFile: string
 }

--- a/license-scanner/types.ts
+++ b/license-scanner/types.ts
@@ -68,7 +68,7 @@ export type ScanOptions = {
   rust: ScanOptionsRust | null;
   transformItemKey?: (str: string) => string;
   tracker: ScanTracker;
-  detectionOverrides: DetectionOverride[] | null;
+  detectionOverrides: DetectionOverride[];
   meta?: ScanResultItemMetadata;
   logger: Logger;
   /**
@@ -146,8 +146,8 @@ export type CargoMetadataOutputV1 = {
 export interface ScanCliArgs {
   scanRoots: string[];
   exclude: string[];
-  startLinesExcludes: string[] | null;
-  detectionOverrides: DetectionOverride[] | null;
+  startLinesExcludes: string[];
+  detectionOverrides: DetectionOverride[];
   logLevel: LogLevel;
   ensureLicenses: boolean | string[];
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paritytech/license-scanner",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "author": "Parity <admin@parity.io> (https://parity.io)",
   "type": "module",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "dependencies": {
     "async-mutex": "^0.3.2",
+    "commander": "^10.0.0",
     "elfinfo": "^0.4.0-beta",
     "node-fetch": "^3.2.10",
     "p-queue": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "debug": "NODE_OPTIONS='--inspect-brk' yarn run start"
   },
   "dependencies": {
+    "@commander-js/extra-typings": "^10.0.2",
     "async-mutex": "^0.3.2",
     "commander": "^10.0.0",
     "elfinfo": "^0.4.0-beta",

--- a/tests/scanner.test.ts
+++ b/tests/scanner.test.ts
@@ -29,7 +29,7 @@ describe("Scanner tests", () => {
       matchLicense: getLicenseMatcher(licenses),
       dirs: { crates: cratesDir, repositories: repositoriesDir },
       rust: { shouldCheckForCargoLock: true, cargoExecPath: "cargo", rustCrateScannerRoot },
-      detectionOverrides: null,
+      detectionOverrides: [],
       logger: new Logger({ minLevel: process.env.DEBUG ? "debug" : "info" }),
       exclude: [],
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -201,6 +201,11 @@
     "@babel/helper-validator-identifier" "^7.14.9"
     to-fast-properties "^2.0.0"
 
+"@commander-js/extra-typings@^10.0.2":
+  version "10.0.2"
+  resolved "https://registry.yarnpkg.com/@commander-js/extra-typings/-/extra-typings-10.0.2.tgz#eccf15c0b6fb58eadba163e7c6440d6a177401db"
+  integrity sha512-PSGG74fpbc2/WRInbKJbwKiUwdN9YqZSgHxDGMqInUe4G6DTLp90ww12uHMC1U/219qPWI0fLSSjwVDUTdnqIQ==
+
 "@eslint/eslintrc@^1.4.1":
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.4.1.tgz#af58772019a2d271b7e2d4c23ff4ddcba3ccfb3e"

--- a/yarn.lock
+++ b/yarn.lock
@@ -666,6 +666,11 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+commander@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.0.tgz#71797971162cd3cf65f0b9d24eb28f8d303acdf1"
+  integrity sha512-zS5PnTI22FIRM6ylNW8G4Ap0IEOyk62fhLSD0+uHRT9McRCLGpkVNvao4bjimpK/GShynyQkFFxHhwMcETmduA==
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"


### PR DESCRIPTION
- Use [Commander](https://github.com/tj/commander.js) for argument parsing
- Use experimental [Commander extra typing](https://github.com/commander-js/extra-typings) for better typescript support
- `scan` command changes
  - Split the `--ensure-licenses` and `--ensure-any-license` options - different types does not work well with Commander, and it probably wasn't the best idea to combine them in the first place.
  - Remove the `--include` option to have only 1 way of providing the scan roots - the variadic argument
- `dump` command changes
  - Removed the format option because only 1 format was supported anyway. It can always be brought back if more formats are needed.