### PR TITLE
Pin to a working version of `action-autotag`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
       tagname: ${{ steps.autotag.outputs.tagname }}
     steps:
     - uses: actions/checkout@v3.3.0
-    - uses: butlerlogic/action-autotag@stable
+    - uses: butlerlogic/action-autotag@1.1.2
       id: autotag
       with:
         head_branch: master


### PR DESCRIPTION
The `stable` branch is failing - pinning to a working version [as other people are doing](https://github.com/ButlerLogic/action-autotag/issues/46#issuecomment-1861928321).