### PR TITLE
Add an option to ensure product references are correct

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -78,7 +78,7 @@ jobs:
         run: |
           license-scanner scan \
             --ensure-product 'Polkadot' \
-            -- ./polkadot/xcm/src/lib.rs \
+            -- ./xcm/src/lib.rs \
             2>out.txt \
             && exit 1 || true
             # We expected it to fail because there are some copy-paste errors.

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -63,12 +63,11 @@ jobs:
         run: |
           shopt -s globstar
 
-          license-scanner scan \
+          ! license-scanner scan \
             --ensure-licenses Apache-2.0 GPL-3.0-only \
             --exclude ./**/target ./**/weights \
             -- ./**/src/**/*.rs \
-            2>out.txt \
-            && exit 1 || true
+            2>out.txt
             # We expected it to fail because there are some unlicensed files left.
           
           grep -q 'No license detected in reconstruct.rs. Exact file path:' ./out.txt

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -74,3 +74,15 @@ jobs:
           grep -q 'No license detected in reconstruct.rs. Exact file path:' ./out.txt
           grep -q 'No license detected in mod.rs. Exact file path:' ./out.txt
         working-directory: polkadot
+      - name: Enforce product references in headers
+        run: |
+          license-scanner scan \
+            --ensure-product 'Polkadot' \
+            -- ./polkadot/xcm/src/lib.rs \
+            2>out.txt \
+            && exit 1 || exit 0
+            # We expected it to fail because there are some copy-paste errors.
+          
+          grep -q 'Product mismatch' ./out.txt
+          grep -q 'Expected "Polkadot", detected "Substrate" in line:' ./out.txt
+        working-directory: polkadot

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -68,7 +68,7 @@ jobs:
             --exclude ./**/target ./**/weights \
             -- ./**/src/**/*.rs \
             2>out.txt \
-            && exit 1 || exit 0
+            && exit 1 || true
             # We expected it to fail because there are some unlicensed files left.
           
           grep -q 'No license detected in reconstruct.rs. Exact file path:' ./out.txt
@@ -80,7 +80,7 @@ jobs:
             --ensure-product 'Polkadot' \
             -- ./polkadot/xcm/src/lib.rs \
             2>out.txt \
-            && exit 1 || exit 0
+            && exit 1 || true
             # We expected it to fail because there are some copy-paste errors.
           
           grep -q 'Product mismatch' ./out.txt

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -76,11 +76,11 @@ jobs:
         working-directory: polkadot
       - name: Enforce product references in headers
         run: |
-          license-scanner scan \
+          set -e      
+          ! license-scanner scan \
             --ensure-product 'Polkadot' \
             -- ./xcm/src/lib.rs \
-            2>out.txt \
-            && exit 1 || true
+            2>out.txt
             # We expected it to fail because there are some copy-paste errors.
           
           grep -q 'Product mismatch' ./out.txt

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -76,7 +76,6 @@ jobs:
         working-directory: polkadot
       - name: Enforce product references in headers
         run: |
-          set -e      
           ! license-scanner scan \
             --ensure-product 'Polkadot' \
             -- ./xcm/src/lib.rs \

--- a/README.md
+++ b/README.md
@@ -276,6 +276,28 @@ yarn start -- scan --ensure-any-license /directory/or/file
 Those options are conflicting with each other so only one should be specified.
 By default, no licensing is enforced.
 
+## `--ensure-product` <a name="ensure-product"></a>
+
+If configured, the scan will make sure that if a license header references a product,
+it will be the correct product and not a result of a copy-paste error.
+
+For example, this fragment references the `Substrate` product.
+
+```text
+// Substrate is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+```
+
+Examples:
+
+```bash
+yarn start -- scan --ensure-product Polkadot -- /directory/or/file
+```
+
+It treats a different product reference as an error, but it allows a generic "this program".
+
 ## `--exclude` <a name="exclude"></a>
 
 Can be used to exclude files or directories from the scan.

--- a/license-scanner/cli/scan.ts
+++ b/license-scanner/cli/scan.ts
@@ -86,6 +86,7 @@ export const executeScan = async function ({
   detectionOverrides,
   logLevel,
   ensureLicenses,
+  ensureProduct,
   exclude,
 }: ScanCliArgs) {
   const licenses = await loadLicensesNormalized(joinPath(buildRoot, "licenses"), {
@@ -119,6 +120,7 @@ export const executeScan = async function ({
       detectionOverrides: detectionOverrides ?? null,
       logger,
       ensureLicenses,
+      ensureProduct,
     });
     allLicensingErrors.push(...licensingErrors);
   }

--- a/license-scanner/license.ts
+++ b/license-scanner/license.ts
@@ -2,7 +2,7 @@ import assert from "assert";
 import fs from "fs";
 import { promisify } from "util";
 
-import { EnsureLicensesInResultOptions, LicenceMatcher, License, LicenseInput } from "./types";
+import { EnsureLicensesInResultOptions, License, LicenseInput } from "./types";
 import { isBinaryFile, loadFiles } from "./utils";
 
 const openAsync = promisify(fs.open);
@@ -79,7 +79,7 @@ const spdxLicenseIdentifierMatcher = new RegExp(`${spdxLicenseIdentifierPrefix}[
 
 const triggerAccumulationRegExp = copyrightTailRegExp.concat(spdxLicenseIdentifierTailRegExp);
 
-export const getLicenseMatcher = function (licenses: License[], startLinesExcludes?: string[]): LicenceMatcher {
+export const getLicenseMatcher = function (licenses: License[], startLinesExcludes?: string[]) {
   const bufSize = Math.max(
     4096,
     ...licenses.map(({ text, match }) => {

--- a/license-scanner/main.ts
+++ b/license-scanner/main.ts
@@ -47,6 +47,12 @@ program
       "If configured, the scan will make sure that all scanned files are licensed with any license.",
     ).conflicts("ensureLicenses"),
   )
+  .addOption(
+    new Option(
+      "--ensure-product <product>",
+      "If configured, the scan will make sure the product mentioned in the license headers is correct.",
+    ),
+  )
   .option("--exclude <exclude...>", "Can be used to exclude files or directories from the scan.")
   // It's actually correct usage but @commander-js/extra-typings is wrong on this one.
   // eslint-disable-next-line @typescript-eslint/no-misused-promises
@@ -60,6 +66,7 @@ program
         exclude: options.exclude ?? [],
         logLevel: options.logLevel as LogLevel,
         ensureLicenses: readEnsureLicenses(options),
+        ensureProduct: options.ensureProduct,
       });
     } catch (e: any) {
       logger.debug(e.stack);

--- a/license-scanner/scanner.ts
+++ b/license-scanner/scanner.ts
@@ -2,7 +2,7 @@ import assert from "assert";
 import { dirname, join as joinPath, relative as relativePath } from "path";
 
 import { getOrDownloadCrate, getVersionedCrateName } from "./crate";
-import { ensureLicensesInResult } from "./license";
+import { ensureLicensesInResult, ensureProductInFile } from "./license";
 import { getOrDownloadRepository } from "./repository";
 import { scanQueue, scanQueueSize } from "./synchronization";
 import {
@@ -133,6 +133,7 @@ export const scan = async function (options: ScanOptions): Promise<ScanResult> {
     tracker,
     logger,
     ensureLicenses = false,
+    ensureProduct,
   } = options;
 
   const licensingErrors: Error[] = [];
@@ -179,6 +180,8 @@ export const scan = async function (options: ScanOptions): Promise<ScanResult> {
       const result = await matchLicense(file.path);
       const licensingError = ensureLicensesInResult({ file, result, ensureLicenses });
       if (licensingError) licensingErrors.push(licensingError);
+      const productError = ensureProductInFile(file.path, ensureProduct);
+      if (productError) licensingErrors.push(productError);
       if (result === undefined) {
         return;
       }

--- a/license-scanner/types.ts
+++ b/license-scanner/types.ts
@@ -55,8 +55,6 @@ export type ScanResult = {
   licensingErrors: Error[];
 };
 
-export type LicenceMatcher = (file: string) => Promise<ScanResultItem | undefined>;
-
 export type ScanOptions = {
   saveResult: (projectId: string, filePathFromRoot: string, result: ScanResultItem) => Promise<void>;
   root: string;
@@ -66,7 +64,7 @@ export type ScanOptions = {
     repositories: string;
     crates: string;
   };
-  matchLicense: LicenceMatcher;
+  matchLicense: (file: string) => Promise<ScanResultItem | undefined>;
   rust: ScanOptionsRust | null;
   transformItemKey?: (str: string) => string;
   tracker: ScanTracker;

--- a/license-scanner/types.ts
+++ b/license-scanner/types.ts
@@ -55,6 +55,8 @@ export type ScanResult = {
   licensingErrors: Error[];
 };
 
+export type LicenceMatcher = (file: string) => Promise<ScanResultItem | undefined>;
+
 export type ScanOptions = {
   saveResult: (projectId: string, filePathFromRoot: string, result: ScanResultItem) => Promise<void>;
   root: string;
@@ -64,7 +66,7 @@ export type ScanOptions = {
     repositories: string;
     crates: string;
   };
-  matchLicense: (file: string) => Promise<ScanResultItem | undefined>;
+  matchLicense: LicenceMatcher;
   rust: ScanOptionsRust | null;
   transformItemKey?: (str: string) => string;
   tracker: ScanTracker;
@@ -77,6 +79,11 @@ export type ScanOptions = {
    * all source files have one of those licenses detected.
    */
   ensureLicenses?: boolean | string[];
+  /**
+   * If true, the scan will make sure that
+   * the license headers contain the correct product name.
+   */
+  ensureProduct?: string | undefined;
 };
 
 export type LicenseInput = {
@@ -150,6 +157,7 @@ export interface ScanCliArgs {
   detectionOverrides: DetectionOverride[];
   logLevel: LogLevel;
   ensureLicenses: boolean | string[];
+  ensureProduct: string | undefined;
 }
 
 export interface DumpCliArgs {


### PR DESCRIPTION
- Introduces a `--ensure-product` option, similar to `--ensure-license`.
  It makes sure we have correct product references in the headers.
- Needed for https://github.com/paritytech/license-scanner/issues/49
- Also fixed an old mistake in the test workflow.