### PR TITLE
Ensure license headers adher to Cargo manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,16 @@ Can be used to exclude files or directories from the scan.
 - Most useful in the combination with `--ensure-licenses`.
 - The excluded path can be absolute or relative.
 
+## `--file-extensions` <a name="file-extensions"></a>
+
+Scan only files with the specified extensions.
+
+Examples:
+
+```bash
+yarn start -- scan --ensure-licenses Apache-2.0 --file-extensions '.rs' -- /directory/or/file
+```
+
 # Implementation <a name="implementation"></a>
 
 [`scan`](https://github.com/paritytech/license-scanner/blob/668b8c5f1cfa1dfc8f22170562f648a344cb60ef/license-scanner/scanner.ts#L141)

--- a/license-scanner/cli/scan.ts
+++ b/license-scanner/cli/scan.ts
@@ -86,6 +86,7 @@ export const executeScan = async function ({
   detectionOverrides,
   logLevel,
   ensureLicenses,
+  fileExtensions,
   exclude,
 }: ScanCliArgs) {
   const licenses = await loadLicensesNormalized(joinPath(buildRoot, "licenses"), {
@@ -112,6 +113,7 @@ export const executeScan = async function ({
       matchLicense,
       root: scanRoot,
       initialRoot: scanRoot,
+      fileExtensions,
       exclude,
       dirs: { crates: cratesDir, repositories: repositoriesDir },
       rust: { shouldCheckForCargoLock: true, cargoExecPath: "cargo", rustCrateScannerRoot },

--- a/license-scanner/license.ts
+++ b/license-scanner/license.ts
@@ -278,7 +278,7 @@ export const ensureLicensesInResult = function ({
   file,
   result,
   ensureLicenses,
-  manifestLicense
+  manifestLicense,
 }: EnsureLicensesInResultOptions): Error | undefined {
   if (ensureLicenses === false) return;
   if (result === undefined) {
@@ -338,7 +338,8 @@ export const ensureProductInFile = function (filePath: string, product: string |
 export const throwLicensingErrors = function (licensingErrors: Error[]) {
   if (licensingErrors.length === 0) return;
   throw new Error(
-    "Encountered the following errors when enforcing licenses:\n" + "• " +
+    "Encountered the following errors when enforcing licenses:\n" +
+      "• " +
       licensingErrors.map((error) => error.message).join("\n• "),
   );
 };

--- a/license-scanner/license.ts
+++ b/license-scanner/license.ts
@@ -339,7 +339,6 @@ export const throwLicensingErrors = function (licensingErrors: Error[]) {
   if (licensingErrors.length === 0) return;
   throw new Error(
     "Encountered the following errors when enforcing licenses:\n" +
-      "• " +
-      licensingErrors.map((error) => error.message).join("\n• "),
+    licensingErrors.map((error) => error.message).join("\n"),
   );
 };

--- a/license-scanner/license.ts
+++ b/license-scanner/license.ts
@@ -302,7 +302,7 @@ export const ensureLicensesInResult = function ({
 export const throwLicensingErrors = function (licensingErrors: Error[]) {
   if (licensingErrors.length === 0) return;
   throw new Error(
-    "Encountered the following errors when enforcing licenses:\n" +
-      licensingErrors.map((error) => error.message).join("\n"),
+    "Encountered the following errors when enforcing licenses:\n" + "• " +
+      licensingErrors.map((error) => error.message).join("\n• "),
   );
 };

--- a/license-scanner/license.ts
+++ b/license-scanner/license.ts
@@ -278,6 +278,7 @@ export const ensureLicensesInResult = function ({
   file,
   result,
   ensureLicenses,
+  manifestLicense
 }: EnsureLicensesInResultOptions): Error | undefined {
   if (ensureLicenses === false) return;
   if (result === undefined) {
@@ -295,6 +296,13 @@ export const ensureLicensesInResult = function ({
     return new Error(
       `${file.name} has ${result.license} license` +
         `, expected one of: ${ensureLicenses.join(",")}. Exact file path: "${file.path}"`,
+    );
+  }
+
+  if (manifestLicense && result.license !== manifestLicense) {
+    return new Error(
+      `${file.name} has ${result.license} license` +
+        `, expected ${manifestLicense} as in cargo manifest. Exact file path: "${file.path}"`,
     );
   }
 };

--- a/license-scanner/license.ts
+++ b/license-scanner/license.ts
@@ -339,6 +339,6 @@ export const throwLicensingErrors = function (licensingErrors: Error[]) {
   if (licensingErrors.length === 0) return;
   throw new Error(
     "Encountered the following errors when enforcing licenses:\n" +
-    licensingErrors.map((error) => error.message).join("\n"),
+      licensingErrors.map((error) => error.message).join("\n"),
   );
 };

--- a/license-scanner/main.ts
+++ b/license-scanner/main.ts
@@ -47,6 +47,7 @@ program
       "If configured, the scan will make sure that all scanned files are licensed with any license.",
     ).conflicts("ensureLicenses"),
   )
+  .option("--file-extensions <fileExtensions...>", "Scan only files with the specified extensions.")
   .option("--exclude <exclude...>", "Can be used to exclude files or directories from the scan.")
   // It's actually correct usage but @commander-js/extra-typings is wrong on this one.
   // eslint-disable-next-line @typescript-eslint/no-misused-promises
@@ -57,6 +58,7 @@ program
         scanRoots: scanRoots.map((scanRoot) => resolvePath(scanRoot)),
         startLinesExcludes: await readStartLinesExcludes(options.startLinesExcludes),
         detectionOverrides: await readDetectionOverrides(options.detectionOverrides),
+        fileExtensions: options.fileExtensions ?? [],
         exclude: options.exclude ?? [],
         logLevel: options.logLevel as LogLevel,
         ensureLicenses: readEnsureLicenses(options),

--- a/license-scanner/scanner.ts
+++ b/license-scanner/scanner.ts
@@ -1,4 +1,3 @@
-import assert from "assert";
 import { dirname, join as joinPath, relative as relativePath } from "path";
 
 import { getOrDownloadCrate, getVersionedCrateName } from "./crate";
@@ -181,7 +180,12 @@ export const scan = async function (options: ScanOptions): Promise<ScanResult> {
 
     await scanQueue.add(async () => {
       const result = await matchLicense(file.path);
-      const licensingError = ensureLicensesInResult({ file, result, ensureLicenses, manifestLicense: file.manifestLicense });
+      const licensingError = ensureLicensesInResult({
+        file,
+        result,
+        ensureLicenses,
+        manifestLicense: file.manifestLicense,
+      });
       if (licensingError) licensingErrors.push(licensingError);
       const productError = ensureProductInFile(file.path, ensureProduct);
       if (productError) licensingErrors.push(productError);
@@ -197,7 +201,7 @@ export const scan = async function (options: ScanOptions): Promise<ScanResult> {
     const rootCargoToml = joinPath(root, "Cargo.toml");
     const rootCargoLock = joinPath(root, "Cargo.lock");
     if (await existsAsync(rootCargoToml)) {
-      await scanCrates({...rust, shouldCheckForCargoLock: await existsAsync(rootCargoLock)}, options);
+      await scanCrates({ ...rust, shouldCheckForCargoLock: await existsAsync(rootCargoLock) }, options);
     }
   }
 

--- a/license-scanner/scanner.ts
+++ b/license-scanner/scanner.ts
@@ -181,7 +181,7 @@ export const scan = async function (options: ScanOptions): Promise<ScanResult> {
 
     await scanQueue.add(async () => {
       const result = await matchLicense(file.path);
-      const licensingError = ensureLicensesInResult({ file, result, ensureLicenses });
+      const licensingError = ensureLicensesInResult({ file, result, ensureLicenses, manifestLicense: file.manifestLicense });
       if (licensingError) licensingErrors.push(licensingError);
       if (result === undefined) {
         return;

--- a/license-scanner/scanner.ts
+++ b/license-scanner/scanner.ts
@@ -142,7 +142,7 @@ export const scan = async function (options: ScanOptions): Promise<ScanResult> {
       logger.debug(`Excluding file ${file.path}`);
       continue toNextFile;
     }
-    if (fileExtensions.length > 0 && !fileExtensions.some((ext) => file.path.endsWith(ext))) {
+    if (!fileExtensions.some((ext) => file.path.endsWith(ext))) {
       continue toNextFile;
     }
     tracker.setFileKey(file.path, key);

--- a/license-scanner/scanner.ts
+++ b/license-scanner/scanner.ts
@@ -190,10 +190,7 @@ export const scan = async function (options: ScanOptions): Promise<ScanResult> {
     await scanQueue.onSizeLessThan(scanQueueSize);
   }
 
-  if (rust !== null && !ensureLicenses) {
-    // Only perform a scan of the dependencies when we are running a regular scan.
-    // When we're ensuring the licenses are in order,
-    // we are only concerned about our own code - not dependencies.
+  if (rust !== null) {
     const rootCargoToml = joinPath(root, "Cargo.toml");
     if (await existsAsync(rootCargoToml)) {
       await scanCrates(rust, options);

--- a/license-scanner/scanner.ts
+++ b/license-scanner/scanner.ts
@@ -120,6 +120,7 @@ const scanCrates = async function (rust: ScanOptionsRust, options: Omit<ScanOpti
 export const scan = async function (options: ScanOptions): Promise<ScanResult> {
   const {
     saveResult,
+    fileExtensions,
     exclude,
     root,
     rust,

--- a/license-scanner/scanner.ts
+++ b/license-scanner/scanner.ts
@@ -199,9 +199,8 @@ export const scan = async function (options: ScanOptions): Promise<ScanResult> {
 
   if (rust !== null) {
     const rootCargoToml = joinPath(root, "Cargo.toml");
-    const rootCargoLock = joinPath(root, "Cargo.lock");
     if (await existsAsync(rootCargoToml)) {
-      await scanCrates({ ...rust, shouldCheckForCargoLock: await existsAsync(rootCargoLock) }, options);
+      await scanCrates({ ...rust }, options);
     }
   }
 

--- a/license-scanner/scanner.ts
+++ b/license-scanner/scanner.ts
@@ -192,8 +192,9 @@ export const scan = async function (options: ScanOptions): Promise<ScanResult> {
 
   if (rust !== null) {
     const rootCargoToml = joinPath(root, "Cargo.toml");
+    const rootCargoLock = joinPath(root, "Cargo.lock");
     if (await existsAsync(rootCargoToml)) {
-      await scanCrates(rust, options);
+      await scanCrates({...rust, shouldCheckForCargoLock: await existsAsync(rootCargoLock)}, options);
     }
   }
 

--- a/license-scanner/scanner.ts
+++ b/license-scanner/scanner.ts
@@ -142,6 +142,9 @@ export const scan = async function (options: ScanOptions): Promise<ScanResult> {
       logger.debug(`Excluding file ${file.path}`);
       continue toNextFile;
     }
+    if (fileExtensions.length > 0 && !fileExtensions.some((ext) => file.path.endsWith(ext))) {
+      continue toNextFile;
+    }
     tracker.setFileKey(file.path, key);
 
     logger.debug(`Enqueueing file ${file.path}`);
@@ -187,7 +190,10 @@ export const scan = async function (options: ScanOptions): Promise<ScanResult> {
     await scanQueue.onSizeLessThan(scanQueueSize);
   }
 
-  if (rust !== null) {
+  if (rust !== null && !ensureLicenses) {
+    // Only perform a scan of the dependencies when we are running a regular scan.
+    // When we're ensuring the licenses are in order,
+    // we are only concerned about our own code - not dependencies.
     const rootCargoToml = joinPath(root, "Cargo.toml");
     if (await existsAsync(rootCargoToml)) {
       await scanCrates(rust, options);

--- a/license-scanner/scanner.ts
+++ b/license-scanner/scanner.ts
@@ -142,7 +142,7 @@ export const scan = async function (options: ScanOptions): Promise<ScanResult> {
       logger.debug(`Excluding file ${file.path}`);
       continue toNextFile;
     }
-    if (!fileExtensions.some((ext) => file.path.endsWith(ext))) {
+    if (fileExtensions.length > 0 && !fileExtensions.some((ext) => file.path.endsWith(ext))) {
       continue toNextFile;
     }
     tracker.setFileKey(file.path, key);

--- a/license-scanner/scanner.ts
+++ b/license-scanner/scanner.ts
@@ -42,8 +42,7 @@ const scanCrates = async function (rust: ScanOptionsRust, options: Omit<ScanOpti
       .catch(reject);
   });
 
-  if (project.license !== null && project.license !== undefined) {
-    assert(typeof project.license === "string");
+  if (project.license !== null && project.license !== undefined && typeof project.license === "string") {
     await saveResult(initialRoot, transformItemKey("Cargo.toml"), { license: project.license });
   }
 

--- a/license-scanner/scanner.ts
+++ b/license-scanner/scanner.ts
@@ -199,8 +199,12 @@ export const scan = async function (options: ScanOptions): Promise<ScanResult> {
 
   if (rust !== null) {
     const rootCargoToml = joinPath(root, "Cargo.toml");
+    const rootCargoLock = joinPath(root, "Cargo.lock");
     if (await existsAsync(rootCargoToml)) {
-      await scanCrates({ ...rust }, options);
+      await scanCrates(
+        { ...rust, shouldCheckForCargoLock: rust.shouldCheckForCargoLock && (await existsAsync(rootCargoLock)) },
+        options,
+      );
     }
   }
 

--- a/license-scanner/scanner.ts
+++ b/license-scanner/scanner.ts
@@ -1,3 +1,4 @@
+import assert from "assert";
 import { dirname, join as joinPath, relative as relativePath } from "path";
 
 import { getOrDownloadCrate, getVersionedCrateName } from "./crate";
@@ -41,7 +42,8 @@ const scanCrates = async function (rust: ScanOptionsRust, options: Omit<ScanOpti
       .catch(reject);
   });
 
-  if (project.license !== null && project.license !== undefined && typeof project.license === "string") {
+  if (project.license !== null && project.license !== undefined) {
+    assert(typeof project.license === "string");
     await saveResult(initialRoot, transformItemKey("Cargo.toml"), { license: project.license });
   }
 

--- a/license-scanner/types.ts
+++ b/license-scanner/types.ts
@@ -97,6 +97,7 @@ export type EnsureLicensesInResultOptions = {
   file: { path: string; name: string };
   result: ScanResultItem | undefined;
   ensureLicenses: boolean | string[];
+  manifestLicense?: string;
 };
 
 export class DatabaseSaveError extends Error {

--- a/license-scanner/types.ts
+++ b/license-scanner/types.ts
@@ -59,6 +59,7 @@ export type ScanOptions = {
   saveResult: (projectId: string, filePathFromRoot: string, result: ScanResultItem) => Promise<void>;
   root: string;
   initialRoot: string;
+  fileExtensions: string[];
   exclude: string[];
   dirs: {
     repositories: string;
@@ -145,6 +146,7 @@ export type CargoMetadataOutputV1 = {
 
 export interface ScanCliArgs {
   scanRoots: string[];
+  fileExtensions: string[];
   exclude: string[];
   startLinesExcludes: string[];
   detectionOverrides: DetectionOverride[];

--- a/license-scanner/types.ts
+++ b/license-scanner/types.ts
@@ -111,7 +111,7 @@ export class DB {
 }
 
 export type RustCrateScannerOutput = {
-  license: string | null | undefined;
+  license: string | null | undefined | { workspace: true };
   crates: Crate[] | null | undefined;
 };
 

--- a/license-scanner/types.ts
+++ b/license-scanner/types.ts
@@ -116,7 +116,7 @@ export class DB {
 }
 
 export type RustCrateScannerOutput = {
-  license: string | null | undefined | { workspace: true };
+  license: string | null | undefined;
   crates: Crate[] | null | undefined;
 };
 

--- a/license-scanner/utils.ts
+++ b/license-scanner/utils.ts
@@ -22,7 +22,10 @@ export const walkFiles: (
     manifestLicense?: string;
     excluding?: { initialRoot: string; exclude: string[] };
   },
-) => AsyncGenerator<{ path: string; name: string; manifestLicense?: string}> = async function* (dir, { excluding } = {}) {
+) => AsyncGenerator<{ path: string; name: string; manifestLicense?: string }> = async function* (
+  dir,
+  { excluding } = {},
+) {
   if ((await lstatAsync(dir)).isFile()) {
     if (excluding && shouldExclude({ targetPath: dir, ...excluding })) return;
     yield { path: dir, name: path.basename(dir) };
@@ -32,7 +35,7 @@ export const walkFiles: (
   let manifestLicense: string | undefined;
   const rootCargoToml = path.join(dir, "Cargo.toml");
   if (await existsAsync(rootCargoToml)) {
-    const manifest = fs.readFileSync(rootCargoToml, "utf-8")
+    const manifest = fs.readFileSync(rootCargoToml, "utf-8");
     manifestLicense = manifest.match(/license = "(.*)"/)?.[1];
   }
 

--- a/license-scanner/utils.ts
+++ b/license-scanner/utils.ts
@@ -16,6 +16,11 @@ export const lstatAsync = promisify(fs.lstat);
 export const writeFileAsync = promisify(fs.writeFile);
 const mkdirAsync = promisify(fs.mkdir);
 
+/**
+ * Recursively traverses down the given directory and yields all found files.
+ * The files contained within the score of a Cargo.toml manifest are annotated with
+ * the corresponding license, if it exists.
+ */
 export const walkFiles: (
   dir: string,
   options?: {

--- a/license-scanner/utils.ts
+++ b/license-scanner/utils.ts
@@ -22,17 +22,15 @@ export const walkFiles: (
     manifestLicense?: string;
     excluding?: { initialRoot: string; exclude: string[] };
   },
-) => AsyncGenerator<{ path: string; name: string; manifestLicense?: string }> = async function* (
-  dir,
-  { excluding } = {},
-) {
+) => AsyncGenerator<{ path: string; name: string; manifestLicense?: string }> = async function* (dir, options = {}) {
+  const { excluding } = options;
   if ((await lstatAsync(dir)).isFile()) {
     if (excluding && shouldExclude({ targetPath: dir, ...excluding })) return;
-    yield { path: dir, name: path.basename(dir) };
+    yield { path: dir, name: path.basename(dir), manifestLicense: options.manifestLicense };
     return;
   }
 
-  let manifestLicense: string | undefined;
+  let manifestLicense = options.manifestLicense;
   const rootCargoToml = path.join(dir, "Cargo.toml");
   if (await existsAsync(rootCargoToml)) {
     const manifest = fs.readFileSync(rootCargoToml, "utf-8");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paritytech/license-scanner",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "author": "Parity <admin@parity.io> (https://parity.io)",
   "type": "module",
   "license": "Apache-2.0",

--- a/rust-crate-scanner/Cargo.lock
+++ b/rust-crate-scanner/Cargo.lock
@@ -10,20 +10,25 @@ checksum = "7fb04b88bd5b2036e30704f95c6ee16f3b5ca3b4ca307da2889d9006648e5c88"
 dependencies = [
  "semver",
  "serde",
- "toml",
+ "toml 0.5.8",
  "url",
 ]
 
 [[package]]
 name = "cargo_toml"
-version = "0.10.1"
+version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6d613611c914a7db07f28526941ce1e956d2f977b0c5e2014fbfa42230d420f"
+checksum = "ad639525b1c67b6a298f378417b060fbc04618bea559482a8484381cce27d965"
 dependencies = [
  "serde",
- "serde_derive",
- "toml",
+ "toml 0.8.19",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "form_urlencoded"
@@ -36,6 +41,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -44,6 +55,16 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
+dependencies = [
+ "equivalent",
+ "hashbrown",
 ]
 
 [[package]]
@@ -59,6 +80,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
+name = "memchr"
+version = "2.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -66,18 +93,18 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.29"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.10"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -90,7 +117,7 @@ dependencies = [
  "cargo_toml",
  "serde",
  "serde_json",
- "toml",
+ "toml 0.5.8",
 ]
 
 [[package]]
@@ -110,18 +137,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.130"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.130"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -140,14 +167,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "syn"
-version = "1.0.80"
+name = "serde_spanned"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d010a1623fbd906d51d650a9916aaefc05ffa0e4053ff7fe601167f3e715d194"
+checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -175,10 +211,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246f4c42e67e7a4e3c6106ff716a5d067d4132a642840b242e357e468a2a0085"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-normalization"
@@ -190,12 +266,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
-
-[[package]]
 name = "url"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -205,4 +275,13 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
+]
+
+[[package]]
+name = "winnow"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
+dependencies = [
+ "memchr",
 ]

--- a/rust-crate-scanner/Cargo.toml
+++ b/rust-crate-scanner/Cargo.toml
@@ -10,6 +10,6 @@ path = "main.rs"
 [dependencies]
 cargo-lock = "7.0.1"
 serde_json = "1.0"
-cargo_toml = "0.10.1"
+cargo_toml = "0.20.4"
 toml = "0.5.8"
 serde = { version = "1.0.130", features = ["derive"] }

--- a/rust-crate-scanner/main.rs
+++ b/rust-crate-scanner/main.rs
@@ -6,7 +6,7 @@ use cargo_toml::Inheritable;
 
 #[derive(Serialize, Deserialize)]
 struct ScanResult {
-  license: Option<String> ,
+  license: Option<String>,
   crates: Option<Vec<serde_json::Value>>,
 }
 

--- a/rust-crate-scanner/main.rs
+++ b/rust-crate-scanner/main.rs
@@ -24,7 +24,6 @@ fn scan(
         format!("Failed to parse {:?}: {:?}", &cargo_toml_path, err)
       })?;
     let package_license = manifest.package.map(|pkg| pkg.license).flatten();
-    let workspace_license = manifest.workspace.clone().map(|ws| ws.package.map(|pkg| pkg.license).flatten()).flatten();
 
     match package_license {
       Some(license) => match license {

--- a/rust-crate-scanner/main.rs
+++ b/rust-crate-scanner/main.rs
@@ -6,7 +6,7 @@ use cargo_toml::Inheritable;
 
 #[derive(Serialize, Deserialize)]
 struct ScanResult {
-  license: Option<Inheritable<String>> ,
+  license: Option<String> ,
   crates: Option<Vec<serde_json::Value>>,
 }
 
@@ -27,11 +27,11 @@ fn scan(
     let workspace_license = manifest.workspace.clone().map(|ws| ws.package.map(|pkg| pkg.license).flatten()).flatten();
 
     match package_license {
-      Some(license) => Some(license),
-      None => match workspace_license {
-        Some(license) => Some(Inheritable::Set(license)),
-        None => None
-      }
+      Some(license) => match license {
+        Inheritable::Set(license) => Some(license),
+        Inheritable::Inherited { .. } => None
+      },
+      None => None
     }
   };
 

--- a/tests/scanner.test.ts
+++ b/tests/scanner.test.ts
@@ -82,6 +82,28 @@ describe("Scanner tests", () => {
     expect(output["futures-0.4.0-alpha.0 file: Cargo.toml"]?.license).to.equal("MIT OR Apache-2.0");
   }).timeout(120_000); // Takes some time because it downloads the crates from the Internet.
 
+  describe("crates with inherited properties", () => {
+    it("targeting the workspace", async () => {
+      const { output, licensingErrors } = await performScan("inherited-properties");
+      expect(licensingErrors.length).to.eq(0);
+
+      // Workspace root.
+      expect(output["Cargo.toml"]?.license).to.equal("MIT");
+      expect(output["src/main.rs"]?.license).to.equal("Apache-2.0");
+
+      // Subpackages.
+      expect(output["subpackage-inherited/src/main.rs"]?.license).to.equal("Apache-2.0");
+      expect(output["subpackage-set/src/main.rs"]?.license).to.equal("Apache-2.0");
+    });
+
+    it("targeting a crate with inherited property directly", async () => {
+      const { output, licensingErrors } = await performScan("inherited-properties/subpackage-inherited");
+      expect(licensingErrors.length).to.eq(0);
+
+      expect(output["src/main.rs"]?.license).to.equal("Apache-2.0");
+    });
+  });
+
   describe("ensure license", () => {
     it("works when file properly licensed", async () => {
       const { output, licensingErrors } = await performScan("required-license/src/licensed", {

--- a/tests/scanner.test.ts
+++ b/tests/scanner.test.ts
@@ -227,5 +227,19 @@ describe("Scanner tests", () => {
         expect(output).to.deep.equal({});
       }
     });
+
+    it("Can exclude files by specifying extensions", async () => {
+      {
+        const { output } = await performScan("single-crate", { });
+        expect(output.LICENSE?.license).to.be.a("string");
+        expect(output["src/main.rs"]?.license).to.be.a("string");
+      }
+
+      {
+        const { output } = await performScan("single-crate", { fileExtensions: [".rs"] });
+        expect(output.LICENSE?.license).to.be.undefined;
+        expect(output["src/main.rs"]?.license).to.be.a("string");
+      }
+    });
   });
 });

--- a/tests/scanner.test.ts
+++ b/tests/scanner.test.ts
@@ -31,6 +31,7 @@ describe("Scanner tests", () => {
       rust: { shouldCheckForCargoLock: true, cargoExecPath: "cargo", rustCrateScannerRoot },
       detectionOverrides: [],
       logger: new Logger({ minLevel: process.env.DEBUG ? "debug" : "info" }),
+      fileExtensions: [],
       exclude: [],
     };
   });

--- a/tests/scanner.test.ts
+++ b/tests/scanner.test.ts
@@ -75,7 +75,7 @@ describe("Scanner tests", () => {
     expect(output["second-crate/src/main.rs"]?.license).to.equal("GPL-3.0-or-later");
   });
 
-  it("create-with-dependencies", async () => {
+  it("crate-with-dependencies", async () => {
     const { output, licensingErrors } = await performScan("crate-with-dependencies");
     expect(licensingErrors.length).to.eq(0);
     expect(output["async-trait-0.1.61 file: Cargo.toml"]?.license).to.equal("MIT OR Apache-2.0");

--- a/tests/scanner.test.ts
+++ b/tests/scanner.test.ts
@@ -151,8 +151,12 @@ describe("Scanner tests", () => {
       {
         const { licensingErrors } = await performScan("manifest-license", scanOpts);
         expect(licensingErrors.length).to.eq(2);
-        expect(licensingErrors.find(e => e.message.includes("main.rs"))!.toString()).to.include("main.rs has MIT license, expected Apache-2.0 as in cargo manifest.");
-        expect(licensingErrors.find(e => e.message.includes("build.rs"))!.toString()).to.include("build.rs has MIT license, expected Apache-2.0 as in cargo manifest.");
+        expect(licensingErrors.find((e) => e.message.includes("main.rs"))!.toString()).to.include(
+          "main.rs has MIT license, expected Apache-2.0 as in cargo manifest.",
+        );
+        expect(licensingErrors.find((e) => e.message.includes("build.rs"))!.toString()).to.include(
+          "build.rs has MIT license, expected Apache-2.0 as in cargo manifest.",
+        );
       }
 
       // The licenses should be OK on their own, they only conflict if the Cargo manifest is considered.

--- a/tests/scanner.test.ts
+++ b/tests/scanner.test.ts
@@ -230,7 +230,7 @@ describe("Scanner tests", () => {
 
     it("Can exclude files by specifying extensions", async () => {
       {
-        const { output } = await performScan("single-crate", { });
+        const { output } = await performScan("single-crate", {});
         expect(output.LICENSE?.license).to.be.a("string");
         expect(output["src/main.rs"]?.license).to.be.a("string");
       }

--- a/tests/targets/inherited-properties/Cargo.toml
+++ b/tests/targets/inherited-properties/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "inherited-properties"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[workspace]
+resolver = "2"
+
+members = [
+	"subpackage-inherited",
+	"subpackage-set",
+]
+
+[dependencies]

--- a/tests/targets/inherited-properties/src/main.rs
+++ b/tests/targets/inherited-properties/src/main.rs
@@ -1,0 +1,18 @@
+// Copyright (C) 2022 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+fn main() {
+  println!("Hello, world!");
+}

--- a/tests/targets/inherited-properties/subpackage-inherited/Cargo.toml
+++ b/tests/targets/inherited-properties/subpackage-inherited/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "subpackage-inherited"
+version = "0.1.0"
+edition = "2021"
+license.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/tests/targets/inherited-properties/subpackage-inherited/src/main.rs
+++ b/tests/targets/inherited-properties/subpackage-inherited/src/main.rs
@@ -1,0 +1,18 @@
+// Copyright (C) 2022 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+fn main() {
+  println!("Hello, world!");
+}

--- a/tests/targets/inherited-properties/subpackage-set/Cargo.toml
+++ b/tests/targets/inherited-properties/subpackage-set/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "subpackage-set"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/tests/targets/inherited-properties/subpackage-set/src/main.rs
+++ b/tests/targets/inherited-properties/subpackage-set/src/main.rs
@@ -1,0 +1,18 @@
+// Copyright (C) 2022 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+fn main() {
+  println!("Hello, world!");
+}

--- a/tests/targets/manifest-license/Cargo.toml
+++ b/tests/targets/manifest-license/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "manifest-license"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/tests/targets/manifest-license/build.rs
+++ b/tests/targets/manifest-license/build.rs
@@ -1,0 +1,24 @@
+// Copyright (C) 2022 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: MIT
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is furnished to do
+// so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+fn main() {
+  println!("Hello, world!");
+}

--- a/tests/targets/manifest-license/src/licensed-differently/main.rs
+++ b/tests/targets/manifest-license/src/licensed-differently/main.rs
@@ -1,0 +1,24 @@
+// Copyright (C) 2022 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: MIT
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+// of the Software, and to permit persons to whom the Software is furnished to do
+// so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+fn main() {
+  println!("Different license!");
+}

--- a/tests/targets/manifest-license/src/licensed/main.rs
+++ b/tests/targets/manifest-license/src/licensed/main.rs
@@ -1,0 +1,18 @@
+// Copyright (C) 2022 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+fn main() {
+  println!("Hello, world!");
+}


### PR DESCRIPTION
- Allows us to ensure that if a license header exists, it matches the Cargo manifest license.
- It's needed by https://github.com/paritytech/license-scanner/issues/44
- Introduce an option to filter by file extensions.
  - So far, for the purpose of ensuring licenses, the tool has been used with a [shell glob](https://github.com/paritytech/polkadot-sdk/blob/655382fa87cd82f12920e316af63084ae098a4e3/.github/workflows/check-licenses.yml#L35). However, we need to use an already-existing functionality of traversing the directories, so that we can propagate the Cargo manifest license down the line.
  - With this, we can close https://github.com/paritytech/license-scanner/issues/45.
- Update the `rust-crate-scanner` to properly parse inherited properties in Cargo.toml.
  - It does NOT completely finish the matter of https://github.com/paritytech/license-scanner/issues/56, but at least it doesn't crash.