### PR TITLE
Fixing publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,6 +38,6 @@ jobs:
           scope: '@paritytech'
       - run: yarn install --immutable
       - run: yarn build
-      - run: yarn publish
+      - run: yarn npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Looks like it's `yarn npm publish` now:
https://yarnpkg.com/cli/npm/publish
https://github.com/paritytech/license-scanner/actions/runs/13502368891/job/37723752541
